### PR TITLE
Isolate IPyKernel to a dedicated module / namespace

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -164,9 +164,13 @@ def init_ipykernel() -> None:
         # Suppress a couple warnings it throws
         warnings.filterwarnings(action="ignore", category=Warning, module="ipykernel")
 
+        # Create a module and namespace for the code to run in: by default the kernel will attach
+        # to the caller, which leads to the `%reset` magic deleting a fair bit of the SDK...
+        import _ipython_user
         # Finally, actually start the kernel
         Thread(
             target=ipykernel.embed.embed_kernel,  # type: ignore
+            kwargs=dict(module=_ipython_user, user_ns=_ipython_user.__dict__),
             name="ipykernel",
             daemon=True,
         ).start()

--- a/src/_ipython_user.py
+++ b/src/_ipython_user.py
@@ -1,0 +1,11 @@
+'''
+This module is used when the IPython kernel is embedded, to contain all the
+code and variables you run.  This is transparent from a user perspective.
+
+You shouldn't really need to know much about it, but it exists so that you don't
+accidentally break the SDK by removing all the code it loads in __main__, and
+things like that.
+
+NOTE: the IPython `%reset` magic will delete anything loaded in here, so it
+doesn't help to import things for future convenience: they won't persist.
+'''


### PR DESCRIPTION
Create a dedicated module for IPyKernel to run code in.  It defaults to using `__main__`, which exposes core parts of the SDK directoly to it.

Normally this wouldn't be so bad, except that various tools like the `%reset` magic can cause some trouble: that one resets the state of the namespace that IPyKernel is in to "default" by deleting almost everything.

Which, it turns out, includes various `_...` variables that are used by the SDK to do almost everything; after running it no mods worked, and in general the SDK was in a kind of broken state.

It might be nice to have access to `__main__` easily, but not as nice as being protected from accidentally destroying everything. :)